### PR TITLE
🐛 Fix ocrd core requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # ocrd includes opencv, numpy, shapely, click
-ocrd >= 2.20.3
+ocrd >= 2.23.3
 keras >= 2.3.1, < 2.4
 scikit-learn >= 0.23.2
 tensorflow-gpu >= 1.15, < 2


### PR DESCRIPTION
eynollah requires at least ocrd >= 2.22.0 for the resource resolving code, otherwise it fails with an AttributeError. Fix this by bumping up the requirement.

Bump it to 2.23.3 so core *also* includes the latest model resource for eynollah.