### PR TITLE
OCR-D CLI: remove allow_enhancement parameter

### DIFF
--- a/qurator/eynollah/ocrd-tool.json
+++ b/qurator/eynollah/ocrd-tool.json
@@ -33,11 +33,6 @@
           "default": false,
           "description": "try to return contour of textlines instead of just rectangle bounding box. Needs more processing time"
         },
-        "allow_enhancement": {
-          "type": "boolean",
-          "default": true,
-          "description": "if the input image has less than 300 DPI, then upscale and enhance"
-        },
         "allow_scaling": {
           "type": "boolean",
           "default": false,

--- a/qurator/eynollah/processor.py
+++ b/qurator/eynollah/processor.py
@@ -37,6 +37,7 @@ class EynollahProcessor(Processor):
             page_id = input_file.pageId or input_file.ID
             LOG.info("INPUT FILE %s (%d/%d) ", page_id, n + 1, len(self.input_files))
             pcgts = page_from_file(self.workspace.download_file(input_file))
+            print('width %s height %s' % (pcgts.get_Page().imageWidth, pcgts.get_Page().imageHeight))
             self.add_metadata(pcgts)
             page = pcgts.get_Page()
             # XXX loses DPI information
@@ -44,7 +45,7 @@ class EynollahProcessor(Processor):
             image_filename = self.workspace.download_file(next(self.workspace.mets.find_files(url=page.imageFilename))).local_filename
             eynollah_kwargs = {
                 'dir_models': self.resolve_resource(self.parameter['models']),
-                'allow_enhancement': self.parameter['allow_enhancement'],
+                'allow_enhancement': False,
                 'curved_line': self.parameter['curved_line'],
                 'full_layout': self.parameter['full_layout'],
                 'allow_scaling': self.parameter['allow_scaling'],


### PR DESCRIPTION
It does not toggle enhancement (eynollah does that internally anyway) but setting it to true will base the coordinate calculations on that enhanced (different-sized) image instead of the original. That is never sensible in the OCR-D context.