### PR TITLE
try loading as TF SavedModel instead of HDF5

### DIFF
--- a/qurator/eynollah/eynollah.py
+++ b/qurator/eynollah/eynollah.py
@@ -515,6 +515,9 @@ class Eynollah:
         gpu_options = tf.compat.v1.GPUOptions(allow_growth=True)
         #gpu_options = tf.compat.v1.GPUOptions(per_process_gpu_memory_fraction=7.7, allow_growth=True)
         session = tf.compat.v1.Session(config=tf.compat.v1.ConfigProto(gpu_options=gpu_options))
+        if model_dir.endswith('.h5') and Path(model_dir[:-3]).exists():
+            # prefer SavedModel over HDF5 format if it exists
+            model_dir = model_dir[:-3]
         model = load_model(model_dir, compile=False)
 
         return model, session


### PR DESCRIPTION
In trying to solve #87, I have converted the models and changed the loader by trying to omit the .h5 suffix.

Unfortunately, I now get a new error:
```
00:49:28.543 INFO eynollah - INPUT FILE PHYS_0005 (1/19) 
00:49:28.824 INFO eynollah - Resizing and enhancing image...
00:49:28.825 INFO eynollah - Detected 300 DPI
Traceback (most recent call last):
  File "/local/ocr-d/ocrd_all/venv/bin/ocrd-eynollah-segment", line 8, in <module>
    sys.exit(main())
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/qurator/eynollah/ocrd_cli.py", line 8, in main
    return ocrd_cli_wrap_processor(EynollahProcessor, *args, **kwargs)
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/ocrd/decorators/__init__.py", line 117, in ocrd_cli_wrap_processor
    run_processor(processorClass, ocrd_tool, mets, workspace=workspace, **kwargs)
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/ocrd/processor/helpers.py", line 107, in run_processor
    processor.process()
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/qurator/eynollah/processor.py", line 58, in process
    Eynollah(**eynollah_kwargs).run()
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/qurator/eynollah/eynollah.py", line 2310, in run
    img_res, is_image_enhanced, num_col_classifier, num_column_is_classified = self.run_enhancement()
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/qurator/eynollah/eynollah.py", line 1993, in run_enhancement
    is_image_enhanced, img_org, img_res, num_col_classifier, num_column_is_classified, img_bin = self.resize_and_enhance_image_with_column_classifier()
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/qurator/eynollah/eynollah.py", line 408, in resize_and_enhance_image_with_column_classifier
    _, page_coord = self.early_page_for_num_of_column_classification(img_bin)
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/qurator/eynollah/eynollah.py", line 654, in early_page_for_num_of_column_classification
    img_page_prediction = self.do_prediction(False, img, model_page)
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/qurator/eynollah/eynollah.py", line 528, in do_prediction
    img_height_model = model.layers[len(model.layers) - 1].output_shape[1]
  File "/local/ocr-d/ocrd_all/venv/lib/python3.8/site-packages/keras/engine/base_layer.py", line 2132, in output_shape
    raise AttributeError(
AttributeError: The layer "activation_56" has never been called and thus has no defined output shape.
```

Given that this seems to be the output layer, I am at a loss here. Creating as draft only.

Ideas anyone?