### PR TITLE
Revert "Merge pull request #97 from qurator-spk/420-namespace-package"

### DIFF
--- a/qurator/__init__.py
+++ b/qurator/__init__.py
@@ -1,0 +1,1 @@
+__import__("pkg_resources").declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import find_namespace_packages, find_packages, setup
+from setuptools import setup, find_packages
 from json import load
 
 install_requires = open('requirements.txt').read().split('\n')
@@ -13,6 +13,7 @@ setup(
     author='Vahid Rezanezhad',
     url='https://github.com/qurator-spk/eynollah',
     license='Apache License 2.0',
+    namespace_packages=['qurator'],
     packages=find_packages(exclude=['tests']),
     install_requires=install_requires,
     package_data={


### PR DESCRIPTION
This reverts commit fd56b86acf55677dc7a8bfb9e2737c3cc167327a (i.e. #97), reversing changes made to ea792d1e4ac4a722770b82dc91e71f84d5beb212 (i.e. 7cd07dd550f1c1f4884aa2cb45339c44db878037).

Motivation: page2tsv and sbb_utils still use `qurator` as namespace, and this inconsistency leads to
```
ModuleNotFoundError: No module named 'qurator.eynollah'
```

