### PR TITLE
update tool json resource path_in_archive

### DIFF
--- a/qurator/eynollah/ocrd-tool.json
+++ b/qurator/eynollah/ocrd-tool.json
@@ -55,9 +55,9 @@
 	  "description": "models for eynollah (TensorFlow format)",
 	  "url": "https://github.com/qurator-spk/eynollah/releases/download/v0.3.0/models_eynollah.tar.gz",
 	  "name": "default",
-	  "size": 1757668443,
+	  "size": 1761991295,
 	  "type": "archive",
-	  "path_in_archive": "default"
+	  "path_in_archive": "models_eynollah"
 	}
       ]
     }


### PR DESCRIPTION
(I don't know when, but obviously the contents of the release archive have been changed, so `ocrd resmgr download` did not work anymore.)