### PR TITLE
update tool json resource path_in_archive

### DIFF
--- a/qurator/eynollah/ocrd-tool.json
+++ b/qurator/eynollah/ocrd-tool.json
@@ -53,11 +53,11 @@
       "resources": [
 	{
 	  "description": "models for eynollah (TensorFlow format)",
-	  "url": "https://qurator-data.de/eynollah/2021-04-25/SavedModel.tar.gz",
+	  "url": "https://github.com/qurator-spk/eynollah/releases/download/v0.3.0/models_eynollah.tar.gz",
 	  "name": "default",
-	  "size": 1483106598,
+	  "size": 1761991295,
 	  "type": "archive",
-	  "path_in_archive": "default"
+	  "path_in_archive": "models_eynollah"
 	}
       ]
     }


### PR DESCRIPTION
version of #105 before #86, needed to make OCR-D work again (see #106) :crossed_fingers: 

(not meant to be merged, only to create a ref on the upstream so ocrd_all can use it for the eynollah submodule; the issue is timing here – we cannot wait for #106 to be fixed, but need #105 since the model archive is now also broken)