### PR TITLE
pil_cv2.check_dpi: fix class membership test

### DIFF
--- a/qurator/eynollah/utils/pil_cv2.py
+++ b/qurator/eynollah/utils/pil_cv2.py
@@ -16,7 +16,7 @@ def pil2cv(img):
 
 def check_dpi(img):
     try:
-        if isinstance(img, Image.__class__):
+        if isinstance(img, Image.Image):
             pil_image = img
         elif isinstance(img, str):
             pil_image = Image.open(img)


### PR DESCRIPTION
(depending on how the `PIL.Image` was instantiated – file plugin or array interface – the previous `isinstance` could fail, provoking a fall-through to `cv2pil` which does not work)

example: `PIL.JpegImagePlugin.JpegImageFile` instances do not match, causing error message from cv2pil → cvtColor:
```
OpenCV(4.6.0) :-1: error: (-5:Bad argument) in function 'cvtColor'
> Overload resolution failed:
>  - src is not a numpy array, neither a scalar
>  - Expected Ptr<cv::UMat> for argument 'src'
```
