### PR TITLE
introduce (temporary) upper bounds for tensorflow and numpy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 * [OCR-D](https://github.com/qurator-spk/eynollah#use-as-ocr-d-processor) interface
 
 ## Installation
-Python versions `3.7-3.10` with Tensorflow `>=2.4` are currently supported.
+Python versions `3.7-3.10` with Tensorflow versions `2.4-2.11` are currently supported. 
 
-For (limited) GPU support the [matching](https://www.tensorflow.org/install/source#gpu) CUDA toolkit `>=10.1` needs to be installed.
+For (limited) GPU support the [matching](https://www.tensorflow.org/install/source#gpu) CUDA toolkit needs to be installed.
 
 You can either install via 
 

--- a/qurator/eynollah/eynollah.py
+++ b/qurator/eynollah/eynollah.py
@@ -29,7 +29,7 @@ warnings.filterwarnings("ignore")
 from scipy.signal import find_peaks
 import matplotlib.pyplot as plt
 from scipy.ndimage import gaussian_filter1d
-from keras.backend import set_session
+from tensorflow.python.keras.backend import set_session
 from tensorflow.keras import layers
 
 from .utils.contour import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # ocrd includes opencv, numpy, shapely, click
 ocrd >= 2.23.3
 scikit-learn >= 0.23.2
-tensorflow >= 2.4.0
+tensorflow >= 2.4.0, <2.12.0
 imutils >= 0.5.3
 matplotlib
 setuptools >= 50

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # ocrd includes opencv, numpy, shapely, click
 ocrd >= 2.23.3
+numpy <1.24.0
 scikit-learn >= 0.23.2
 tensorflow >= 2.4.0, <2.12.0
 imutils >= 0.5.3


### PR DESCRIPTION
This PR introduces temporary upper bounds for tensorflow and numpy versions until we have adapted the codebase to breaking changes. This fixes the build and test.

1. Cap tensorflow version to `<2.12.0` until we have time to adapt to the API and other changes such as e.g.
  * Support for Python 3.11 has been added.
  * Support for Python 3.7 has been removed.  

    See also https://github.com/tensorflow/tensorflow/releases/tag/v2.12.0.

2. Cap numpy version to `<1.24.0` (numpy is shipped unbound via ocrd) which had several deprecations expire that require changes to our codebase such as e.g. 
  * The deprecation for the aliases np.object, np.bool, np.float, np.complex, np.str, and np.int is expired
  * Ragged array creation will now always raise a ValueError unless dtype=object is passed.

    See also here: https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations

3. This also includes a fix for `keras.backend` import error with Python >=3.8