### PR TITLE
OCR-D v3 API: fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,5 @@ Repository = "https://github.com/qurator-spk/eynollah.git"
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 
-[tool.setuptools.packages.find]
-where = ["qurator"]
-
 [tool.setuptools.package-data]
 "*" = ["*.json", '*.yml', '*.xml', '*.xsd']

--- a/qurator/eynollah/ocrd-tool.json
+++ b/qurator/eynollah/ocrd-tool.json
@@ -6,8 +6,8 @@
       "executable": "ocrd-eynollah-segment",
       "categories": ["Layout analysis"],
       "description": "Segment page into regions and lines and do reading order detection with eynollah",
-      "input_file_grp": ["OCR-D-IMG", "OCR-D-SEG-PAGE", "OCR-D-GT-SEG-PAGE"],
-      "output_file_grp": ["OCR-D-SEG-LINE"],
+      "input_file_grp_cardinality": 1,
+      "output_file_grp_cardinality": 1,
       "steps": ["layout/segmentation/region", "layout/segmentation/line"],
       "parameters": {
         "models": {

--- a/qurator/eynollah/processor.py
+++ b/qurator/eynollah/processor.py
@@ -6,10 +6,6 @@ from .eynollah import Eynollah
 
 class EynollahProcessor(Processor):
 
-    @property
-    def metadata_filename(self) -> str:
-        return 'eynollah/ocrd-tool.json'
-
     def setup(self) -> None:
         # for caching models
         self.models = None


### PR DESCRIPTION
- The current pyproject.toml does not install eynollah as a namespace pkg in qurator namespace anymore – dfc4ac2538654ef446beb69652ea64543db2cc93 fixes that.
- If indeed a namespace pkg is present, then ocrd==3.0.0b2 still does not work, because importlib_resources says `Can't open orphan path` – https://github.com/OCR-D/core/pull/1240/commits/1ed38a6a7559bc0c109e8130220de49698796efd fixes that in core, 1e902571ead1b8493376e2ca7d1dc401aefd929d here.
- The fileGrp cardinalities were still not in the tool json – 17eafc1ccb3980f2bedb5183d45942fc83a838ba fixes that.