### PR TITLE
Ocrd fixes

### DIFF
--- a/src/eynollah/ocrd-tool.json
+++ b/src/eynollah/ocrd-tool.json
@@ -38,7 +38,7 @@
          "textline_light": {
           "type": "boolean",
           "default": true,
-          "description": "Light version need textline light"
+          "description": "Light version need textline light. If this parameter set to true, this tool will try to return contoure of textlines instead of rectangle bounding box of textline with a faster method."
         },
         "tables": {
           "type": "boolean",
@@ -64,11 +64,6 @@
           "type": "boolean",
           "default": false,
           "description": "if this parameter set to true, this tool would check that input image need resizing and enhancement or not."
-        },
-        "textline_light": {
-          "type": "boolean",
-          "default": false,
-          "description": "if this parameter set to true, this tool will try to return contoure of textlines instead of rectangle bounding box of textline with a faster method."
         },
         "right_to_left": {
           "type": "boolean",

--- a/src/eynollah/processor.py
+++ b/src/eynollah/processor.py
@@ -14,9 +14,10 @@ class EynollahProcessor(Processor):
         return 'ocrd-eynollah-segment'
 
     def setup(self) -> None:
-        if self.parameter['textline_light'] and not self.parameter['light_version']:
-            raise ValueError("Error: You set parameter 'textline_light' to enable light textline detection, "
-                             "but parameter 'light_version' is not enabled")
+        assert self.parameter
+        if self.parameter['textline_light'] != self.parameter['light_version']:
+            raise ValueError("Error: You must set or unset both parameter 'textline_light' (to enable light textline detection), "
+                             "and parameter 'light_version' (faster+simpler method for main region detection and deskewing)")
         self.eynollah = Eynollah(
             self.resolve_resource(self.parameter['models']),
             logger=self.logger,


### PR DESCRIPTION
As discussed: `textline_light` must always be the same as `light_version`, as it does in the standalone CLI.

Which begs the question why there are two parameters though?