### PR TITLE
pil2cv: allow (and drop) alpha channels on input imgs

### DIFF
--- a/src/eynollah/ocrd_cli_binarization.py
+++ b/src/eynollah/ocrd_cli_binarization.py
@@ -10,16 +10,7 @@ from ocrd_models.ocrd_page import OcrdPage, AlternativeImageType
 from ocrd.decorators import ocrd_cli_options, ocrd_cli_wrap_processor
 
 from .sbb_binarize import SbbBinarizer
-
-
-def cv2pil(img):
-    return Image.fromarray(img.astype('uint8'))
-
-def pil2cv(img):
-    # from ocrd/workspace.py
-    color_conversion = cv2.COLOR_GRAY2BGR if img.mode in ('1', 'L') else  cv2.COLOR_RGB2BGR
-    pil_as_np_array = np.array(img).astype('uint8') if img.mode == '1' else np.array(img)
-    return cv2.cvtColor(pil_as_np_array, color_conversion)
+from .utils.pil_cv2 import cv2pil, pil2cv
 
 class SbbBinarizeProcessor(Processor):
     # already employs GPU (without singleton process atm)

--- a/src/eynollah/utils/pil_cv2.py
+++ b/src/eynollah/utils/pil_cv2.py
@@ -11,8 +11,12 @@ def cv2pil(img):
 
 def pil2cv(img):
     # from ocrd/workspace.py
-    color_conversion = COLOR_GRAY2BGR if img.mode in ('1', 'L') else  COLOR_RGB2BGR
+    color_conversion = COLOR_GRAY2BGR if img.mode in ('1', 'L', 'LA') else  COLOR_RGB2BGR
     pil_as_np_array = np.array(img).astype('uint8') if img.mode == '1' else np.array(img)
+    if pil_as_np_array.shape[-1] == 2:
+        pil_as_np_array = pil_as_np_array[:,:,0]
+    elif pil_as_np_array.shape[-1] == 4:
+        pil_as_np_array = pil_as_np_array[:,:,:3]
     return cvtColor(pil_as_np_array, color_conversion)
 
 def check_dpi(img):

--- a/src/eynollah/utils/pil_cv2.py
+++ b/src/eynollah/utils/pil_cv2.py
@@ -7,12 +7,14 @@ from cv2 import COLOR_GRAY2BGR, COLOR_RGB2BGR, COLOR_BGR2RGB, cvtColor, imread
 # from sbb_binarization
 
 def cv2pil(img):
-    return Image.fromarray(np.array(cvtColor(img, COLOR_BGR2RGB)))
+    # reduce depth because cvtColor is limited
+    return Image.fromarray(np.array(cvtColor(img.astype(np.uint8), COLOR_BGR2RGB)))
 
 def pil2cv(img):
     # from ocrd/workspace.py
     color_conversion = COLOR_GRAY2BGR if img.mode in ('1', 'L', 'LA') else  COLOR_RGB2BGR
     pil_as_np_array = np.array(img).astype('uint8') if img.mode == '1' else np.array(img)
+    # cvtColor cannot handle alpha
     if pil_as_np_array.shape[-1] == 2:
         pil_as_np_array = pil_as_np_array[:,:,0]
     elif pil_as_np_array.shape[-1] == 4:


### PR DESCRIPTION
The error I got by calling `cvtColor` as it was:

```
OpenCV(4.8.0) /io/opencv/modules/imgproc/src/color.simd_helpers.hpp:92: error: (-2:Unspecified error) in function 'cv::impl::{anonymous}::CvtHelper<VScn, VDcn, VDepth, sizePolicy>::CvtHelper(cv::InputArray, cv::OutputArray, int) [with VScn = cv::impl::{anonymous}::Set<1>; VDcn = cv::impl::{anonymous}::Set<3, 4>; VDepth = cv::impl::{anonymous}::Set<0, 2, 5>; cv::impl::{anonymous}::SizePolicy sizePolicy = cv::impl::<unnamed>::NONE; cv::InputArray = const cv::_InputArray&; cv::OutputArray = const cv::_OutputArray&]'
> Invalid number of channels in input image:
>     'VScn::contains(scn)'
> where
>     'scn' is 2
```

Removing the alpha channel in advance avoids the problem.

But perhaps we should not naively drop the channel, but use it (somehow) to **mask** the image? (I.e. for segmentation: no layout analysis in fully transparent zones, for binarization: pure background)